### PR TITLE
fix: code block copy button, & related UI nits

### DIFF
--- a/packages/components/src/components/alert.tsx
+++ b/packages/components/src/components/alert.tsx
@@ -14,8 +14,8 @@ const alertStyles = tv({
         'border-light border',
         'bg-tint-light/80',
         'text-mid',
-        'py-1 pr-2 pl-3',
-        'flex items-center gap-4',
+        'p-2 pl-3',
+        'flex items-center gap-3',
     ],
 })
 

--- a/packages/components/src/components/code-block.tsx
+++ b/packages/components/src/components/code-block.tsx
@@ -1,13 +1,22 @@
 import { CopyIcon } from 'lucide-react'
+import { useCallback } from 'react'
 import { Prism as SyntaxHighlighter, type SyntaxHighlighterProps } from 'react-syntax-highlighter'
 
-import { Button } from './button'
+import { FieldButton } from './field-button'
 import { Tooltip, TooltipTrigger } from './tooltip'
 
 /**
  * A syntax-highlighted code block component, built using `react-syntax-highlighter`.
  */
 export function CodeBlock({ showLineNumbers = true, ...props }: SyntaxHighlighterProps) {
+    const copyValue = useCallback(() => {
+        if (props.children === '' || props.children.length === 0) return
+        const valueToCopy =
+            typeof props.children === 'string' ? props.children : props.children.join('\n')
+
+        return navigator.clipboard.writeText(valueToCopy)
+    }, [props.children])
+
     return (
         <div className='relative w-full'>
             <SyntaxHighlighter
@@ -20,15 +29,14 @@ export function CodeBlock({ showLineNumbers = true, ...props }: SyntaxHighlighte
                 {typeof props.children === 'string' ? props.children.trim() : props.children}
             </SyntaxHighlighter>
             <TooltipTrigger>
-                <Button
+                <FieldButton
                     aria-label='Copy to clipboard'
-                    className='absolute top-0 right-0 !h-6 !w-6 !p-0'
-                    isIcon
-                    variant='secondary'
+                    className='absolute -top-0.75 -right-0.75'
+                    onPress={() => void copyValue()}
                 >
                     <CopyIcon />
-                </Button>
-                <Tooltip placement='left'>Copy to clipboard</Tooltip>
+                </FieldButton>
+                <Tooltip placement='top'>Copy to clipboard</Tooltip>
             </TooltipTrigger>
         </div>
     )

--- a/packages/components/src/components/dialog.tsx
+++ b/packages/components/src/components/dialog.tsx
@@ -69,9 +69,9 @@ const dialogStyles = tv({
     ],
     variants: {
         width: {
-            lg: 'md:max-w-[max(50rem,50dvw)]',
-            md: 'md:max-w-[max(35rem,35dvw)]',
-            sm: 'md:max-w-96',
+            lg: 'md:w-[max(50rem,50dvw)]',
+            md: 'md:w-[max(35rem,35dvw)]',
+            sm: 'md:w-96',
         },
     },
 })

--- a/packages/components/src/components/empty-state.tsx
+++ b/packages/components/src/components/empty-state.tsx
@@ -44,7 +44,7 @@ export function EmptyState({
                 className
             )}
         >
-            <Icon className='text-mid mb-2 block size-6 [&>*]:stroke-[1.5]' />
+            <Icon className='text-mid mb-4 block size-8 [&>*]:stroke-[1.5]' />
 
             <Heading
                 className='text-dark mb-1 text-base'

--- a/packages/components/src/components/tooltip.tsx
+++ b/packages/components/src/components/tooltip.tsx
@@ -7,6 +7,7 @@ import { Info as InfoIcon } from 'lucide-react'
 import { type ComponentProps, type ForwardedRef } from 'react'
 import {
     composeRenderProps,
+    OverlayArrow,
     Tooltip as RACTooltip,
     TooltipTrigger as RACTooltipTrigger,
 } from 'react-aria-components'
@@ -25,7 +26,7 @@ const tooltipStyles = tv({
             'inline-flex items-center gap-1',
             'px-2 py-1',
             'text-sm',
-            'bg-raised border-dark text-mid',
+            'bg-[var(--theme-default-text-dark)] text-[var(--theme-default-bg-raised)]',
             'group rounded drop-shadow-sm',
             // transition
             'transition-all will-change-transform',
@@ -35,18 +36,18 @@ const tooltipStyles = tv({
             '[--origin-x:0]',
             '[--origin-y:0]',
             // placement
-            'placement-top:[--origin-y:theme(spacing.1)]',
-            'placement-right:[--origin-x:calc(theme(spacing.1)_*_-1)]',
-            'placement-bottom:[--origin-y:calc(theme(spacing.1)_*_-1)]',
-            'placement-left:[--origin-x:theme(spacing.1)]',
+            'placement-top:[--origin-y:var(--spacing)]',
+            'placement-right:[--origin-x:calc(var(--spacing)_*_-1)]',
+            'placement-bottom:[--origin-y:calc(var(--spacing)_*_-1)]',
+            'placement-left:[--origin-x:var(--spacing)]',
             // entering
             'entering:opacity-0',
-            'entering:translate-y-[--origin-y]',
-            'entering:translate-x-[--origin-x]',
+            'entering:translate-y-(--origin-y)',
+            'entering:translate-x-(--origin-x)',
             // exiting
             'exiting:opacity-0',
-            'exiting:translate-y-[--origin-y]',
-            'exiting:translate-x-[--origin-x]',
+            'exiting:translate-y-(--origin-y)',
+            'exiting:translate-x-(--origin-x)',
             'exiting:pointer-events-none', // ensure content behind is immediately interactive
         ],
     ],
@@ -67,6 +68,19 @@ export function Tooltip({ children, ...props }: TooltipProps) {
             )}
             offset={10}
         >
+            <OverlayArrow>
+                <svg
+                    className='group-placement-left:-rotate-90 group-placement-right:rotate-90 group-placement-bottom:rotate-180
+                        fill-[var(--theme-default-text-dark)] forced-colors:fill-[Canvas]
+                        forced-colors:stroke-[ButtonBorder]'
+                    height={8}
+                    viewBox='0 0 8 8'
+                    width={8}
+                >
+                    <path d='M0 0 L4 4 L8 0' />
+                </svg>
+            </OverlayArrow>
+
             {children}
         </RACTooltip>
     )

--- a/packages/components/src/styles/focus-ring.ts
+++ b/packages/components/src/styles/focus-ring.ts
@@ -14,7 +14,7 @@ export const focusRing = tv({
         isBorderless: {
             false: [
                 'focus-within:&:has([data-focus-visible]):outline-2 focus-visible:outline-2',
-                'group/invalid:!outline-red-700 invalid:!outline-red-700',
+                'group/invalid:error invalid:error',
             ],
             true: '',
         },

--- a/packages/docs/src/components/docs-search-dialog.tsx
+++ b/packages/docs/src/components/docs-search-dialog.tsx
@@ -59,7 +59,7 @@ export function DocsSearchDialog() {
             <DialogModalOverlay>
                 <DialogModal>
                     <Dialog
-                        className='md:!h-[50vh]'
+                        className='md:!h-[50vh] w-full'
                         width='md'
                     >
                         <Autocomplete>


### PR DESCRIPTION
- Wires up the functionality to copy code to clipboard in `CodeBlock`
- Fixes styles for the tooltip component
- Fixes several small styling nits that were visible in the docs site

Closes #290 