### PR TITLE
fix(MCP): more granular usage examples

### DIFF
--- a/packages/mcp-server/.prettierignore
+++ b/packages/mcp-server/.prettierignore
@@ -1,3 +1,4 @@
 .turbo
+dist
 node_modules
 CHANGELOG.md

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -14,6 +14,7 @@
         "resources"
     ],
     "scripts": {
+        "build": "tsx ./src/scripts/gen-usage.ts",
         "check:eslint": "eslint .",
         "check:prettier": "prettier . --check",
         "check:vitest": "vitest run --passWithNoTests",

--- a/packages/mcp-server/src/scripts/gen-usage.ts
+++ b/packages/mcp-server/src/scripts/gen-usage.ts
@@ -1,0 +1,26 @@
+import usage from '@ui-kit.ai/metadata/usage-examples.json' with { type: 'json' }
+import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const DIST = resolve(__dirname, '../../dist')
+const OUT = join(DIST, 'usage')
+
+const template = (content: string) => `\`\`\`tsx\n${content.trim()}\n\`\`\``
+
+if (existsSync(OUT) === false) mkdirSync(OUT, { recursive: true })
+
+// Process each component and its examples
+Object.entries(usage).forEach(([component, examples]) => {
+    const dir = join(OUT, component)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+
+    Object.entries(examples as Record<string, string>).forEach(([exampleName, content]) => {
+        const outputFilePath = join(dir, `${exampleName}.md`)
+        writeFileSync(outputFilePath, template(content), 'utf-8')
+    })
+})
+
+console.info(`✅ Generated usage example markdown files in ${OUT}`)

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,10 @@
             ],
             "outputLogs": "new-only"
         },
+        "@ui-kit.ai/mcp-server#build": {
+            "dependsOn": ["@ui-kit.ai/metadata#build"],
+            "outputLogs": "new-only"
+        },
         "@ui-kit.ai/metadata#build": {
             "dependsOn": ["@ui-kit.ai/components#build", "@ui-kit.ai/storybook#build"],
             "outputLogs": "new-only"
@@ -47,7 +51,7 @@
             ],
             "outputLogs": "new-only"
         },
-        "@ui-kit.ai/storybook#storycap:light": {
+        "@ui-kit.ai/storybook#storycap:dark": {
             "dependsOn": [
                 "@ui-kit.ai/components#build",
                 "@ui-kit.ai/theme#build",
@@ -55,7 +59,7 @@
             ],
             "outputLogs": "new-only"
         },
-        "@ui-kit.ai/storybook#storycap:dark": {
+        "@ui-kit.ai/storybook#storycap:light": {
             "dependsOn": [
                 "@ui-kit.ai/components#build",
                 "@ui-kit.ai/theme#build",
@@ -65,7 +69,7 @@
         },
         "build": {
             "outputLogs": "new-only",
-            "outputs": ["dist/**", ".next/**"]
+            "outputs": ["dist/**", ".next/**", "out/**"]
         },
         "check": {
             "dependsOn": ["build", "check:prettier", "check:tsc", "check:vitest"],
@@ -105,9 +109,9 @@
             "outputLogs": "new-only"
         },
         "publish-packages": {
+            "cache": false,
             "dependsOn": ["check", "build", "^publish-packages"],
-            "outputLogs": "new-only",
-            "cache": false
+            "outputLogs": "new-only"
         },
         "storybook": {
             "dependsOn": ["^storybook"],


### PR DESCRIPTION
Breaks up the usage examples served by the MCP server into smaller chunks, which (anecdotally) seems to promote better results, by not overwhelming the context window with (oft-repeated) tokens.