### PR TITLE
fix: overlay styles

### DIFF
--- a/packages/components/src/components/dialog.tsx
+++ b/packages/components/src/components/dialog.tsx
@@ -25,7 +25,7 @@ const modalOverlayStyles = tv({
         'fixed inset-0 z-50',
         'h-dvh w-dvw',
         'flex items-center justify-center text-center',
-        'bg-base/25 backdrop-blur-[2px]',
+        // 'bg-[#000000]/25 backdrop-blur-[2px]',
         // transition properties
         'transition-opacity ease-out',
         // entering
@@ -38,14 +38,20 @@ const modalOverlayStyles = tv({
 
 const modalStyles = tv({
     base: [
-        'h-auto w-auto md:max-h-[75dvh]',
+        'h-dvh w-dvw md:h-auto md:w-auto md:max-h-[75dvh]',
         'flex items-center justify-center',
         'relative',
         'forced-colors:bg-[Canvas]',
         // transition
-        'transition-transform ease-out',
-        'md:entering:translate-y-4',
-        'md:exiting:translate-y-4',
+        'transition-transform duration-200',
+        // entering
+        // 'md:entering:translate-y-4',
+        'entering:ease-out',
+        'md:entering:scale-95',
+        // exiting
+        // 'md:exiting:translate-y-4',
+        'entering:ease-in',
+        'md:entering:scale-98',
         'exiting:pointer-events-none', // ensure content behind is immediately interactive
     ],
 })
@@ -60,12 +66,12 @@ const dialogStyles = tv({
         'text-left',
         'bg-raised/80 backdrop-blur-[2px]',
         // height
-        'sm:max-sm:h-dvh sm:max-sm:max-h-dvh',
-        'h-[unset] max-h-[inherit]',
-        'w-full sm:max-sm:max-w-[100dvw]',
+        'h-dvh md:h-[unset] max-h-dvh',
+        'w-full max-w-[100dvw]',
         // border
-        'sm:max-sm:rounded-none sm:max-sm:border-0',
-        'border-mid rounded-lg border',
+        'rounded-none md:rounded-lg',
+        'sm:max-sm:border-0',
+        'border-mid border',
         '[[data-placement]>&]:p-4',
     ],
     variants: {

--- a/packages/components/src/components/dialog.tsx
+++ b/packages/components/src/components/dialog.tsx
@@ -38,7 +38,7 @@ const modalOverlayStyles = tv({
 
 const modalStyles = tv({
     base: [
-        'h-dvh w-dvw md:h-auto md:w-auto md:max-h-[75dvh]',
+        'h-dvh w-dvw md:h-auto md:max-h-[75dvh] md:w-auto',
         'flex items-center justify-center',
         'relative',
         'forced-colors:bg-[Canvas]',
@@ -66,7 +66,7 @@ const dialogStyles = tv({
         'text-left',
         'bg-raised/80 backdrop-blur-[2px]',
         // height
-        'h-dvh md:h-[unset] max-h-dvh',
+        'h-dvh max-h-dvh md:h-[unset]',
         'w-full max-w-[100dvw]',
         // border
         'rounded-none md:rounded-lg',

--- a/packages/components/src/components/popover.tsx
+++ b/packages/components/src/components/popover.tsx
@@ -21,19 +21,33 @@ interface PopoverProps extends Omit<AriaPopoverProps, 'children'> {
 
 const popoverStyles = tv({
     base: [
-        `bg-raised/80 border-mid text-dark rounded border shadow-2xl backdrop-blur-xs transition-none
-        forced-colors:bg-[Canvas]`,
+        `bg-raised/80 backdrop-blur-xs rounded`,
+        `text-dark   shadow-2xl forced-colors:bg-[Canvas]`,
+        'border-mid border',
+        // transition
+        'transition-all will-change-transform duration-200',
+        'translate-y-0',
+        'translate-x-0',
+        // transform origin
+        '[--origin-x:0]',
+        '[--origin-y:0]',
+        // placement
+        'placement-top:[--origin-y:var(--spacing)]',
+        'placement-right:[--origin-x:calc(var(--spacing)_*_-1)]',
+        'placement-bottom:[--origin-y:calc(var(--spacing)_*_-1)]',
+        'placement-left:[--origin-x:var(--spacing)]',
+        // entering
+        'entering:ease-out',
+        'entering:opacity-0',
+        'entering:translate-y-(--origin-y)',
+        'entering:translate-x-(--origin-x)',
+        // exiting
+        'entering:ease-in',
+        'exiting:opacity-0',
+        'exiting:translate-y-(--origin-y)',
+        'exiting:translate-x-(--origin-x)',
+        'exiting:pointer-events-none', // ensure content behind is immediately interactive
     ],
-    variants: {
-        isEntering: {
-            true: `animate-in fade-in placement-left:slide-in-from-right-1 placement-right:slide-in-from-left-1
-            placement-top:slide-in-from-bottom-1 placement-bottom:slide-in-from-top-1 ease-out`,
-        },
-        isExiting: {
-            true: `animate-out fade-out placement-left:slide-out-to-right-1 placement-right:slide-out-to-left-1
-            placement-top:slide-out-to-bottom-1 placement-bottom:slide-out-to-top-1 ease-out`,
-        },
-    },
 })
 
 /**

--- a/packages/components/src/components/popover.tsx
+++ b/packages/components/src/components/popover.tsx
@@ -21,11 +21,11 @@ interface PopoverProps extends Omit<AriaPopoverProps, 'children'> {
 
 const popoverStyles = tv({
     base: [
-        `bg-raised/80 backdrop-blur-xs rounded`,
-        `text-dark   shadow-2xl forced-colors:bg-[Canvas]`,
+        'bg-raised/80 rounded backdrop-blur-xs',
+        'text-dark shadow-2xl forced-colors:bg-[Canvas]',
         'border-mid border',
         // transition
-        'transition-all will-change-transform duration-200',
+        'transition-all duration-200 will-change-transform',
         'translate-y-0',
         'translate-x-0',
         // transform origin

--- a/packages/components/src/components/select.tsx
+++ b/packages/components/src/components/select.tsx
@@ -51,7 +51,7 @@ export function Select<T extends OptionsSchema<'listbox'> = OptionsSchema<'listb
             {...props}
             className={(rp) =>
                 twMerge(
-                    'group invalid:error relative w-full',
+                    'group invalid:error relative w-full !outline-0',
                     typeof props.className === 'function' ? props.className(rp) : props.className
                 )
             }

--- a/packages/components/src/components/tooltip.tsx
+++ b/packages/components/src/components/tooltip.tsx
@@ -29,7 +29,7 @@ const tooltipStyles = tv({
             'bg-[var(--theme-default-text-dark)] text-[var(--theme-default-bg-raised)]',
             'group rounded drop-shadow-sm',
             // transition
-            'transition-all will-change-transform',
+            'transition-all will-change-transform duration-200',
             'translate-y-0',
             'translate-x-0',
             // transform origin
@@ -41,10 +41,12 @@ const tooltipStyles = tv({
             'placement-bottom:[--origin-y:calc(var(--spacing)_*_-1)]',
             'placement-left:[--origin-x:var(--spacing)]',
             // entering
+            'entering:ease-out',
             'entering:opacity-0',
             'entering:translate-y-(--origin-y)',
             'entering:translate-x-(--origin-x)',
             // exiting
+            'entering:ease-in',
             'exiting:opacity-0',
             'exiting:translate-y-(--origin-y)',
             'exiting:translate-x-(--origin-x)',

--- a/packages/components/src/components/tooltip.tsx
+++ b/packages/components/src/components/tooltip.tsx
@@ -29,7 +29,7 @@ const tooltipStyles = tv({
             'bg-[var(--theme-default-text-dark)] text-[var(--theme-default-bg-raised)]',
             'group rounded drop-shadow-sm',
             // transition
-            'transition-all will-change-transform duration-200',
+            'transition-all duration-200 will-change-transform',
             'translate-y-0',
             'translate-x-0',
             // transform origin

--- a/packages/components/src/index.css
+++ b/packages/components/src/index.css
@@ -138,7 +138,7 @@ Apply a consistent focus ring to any focus-visible element,
 except when it is a child of already focus-visible element.
 Also to any focus-within element that has a focus-visible child.
 */
-[data-focus-visible],
+[data-focus-visible]:not(:is([aria-autocomplete='list'], [role='menuitem'], [role='listitem'])),
 [data-focus-within]:has([data-focus-visible]) {
     outline: 2px solid;
     outline-color: var(--theme-default-bg-accent-light);

--- a/packages/docs/src/components/top-nav.tsx
+++ b/packages/docs/src/components/top-nav.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { LinkButton, TopNav as UIKitTopNav } from '@ui-kit.ai/components'
+import { Link, LinkButton, TopNav as UIKitTopNav } from '@ui-kit.ai/components'
 import { Github } from 'lucide-react'
-import Link from 'next/link'
 
 import { hrefs } from '../lib/hrefs'
 import { DocsSearchDialog } from './docs-search-dialog'


### PR DESCRIPTION
- adds smoother transition styles to dialogs, popovers & tooltips
- fixes a bug with the docs site top nav where the wrong link component was used, causing inconsistent focus ring 